### PR TITLE
feat: add ext-protobuf mirror

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,4 +1,17 @@
 {
   "$schema": "./registry.schema.json",
-  "extensions": []
+  "extensions": [
+    {
+      "name": "ext-protobuf",
+      "mirror-repo": "pie-extensions/ext-protobuf",
+      "upstream-repo": "protocolbuffers/protobuf",
+      "upstream-type": "github",
+      "packagist-name": "pie-extensions/ext-protobuf",
+      "packagist-registered": false,
+      "php-ext-name": "protobuf",
+      "status": "active",
+      "added": "2026-03-02",
+      "notes": ""
+    }
+  ]
 }


### PR DESCRIPTION
Adds `pie-extensions/ext-protobuf` to the extension registry.

**Upstream:** https://github.com/protocolbuffers/protobuf
**Mirror:** https://github.com/pie-extensions/ext-protobuf

## Manual steps still needed
- [ ] Register on Packagist: https://packagist.org/packages/submit
- [ ] Set up Packagist webhook on the mirror repo
- [ ] Update `packagist-registered: true` in registry.json