### PR TITLE
feat: add protobuf mirror

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -7,7 +7,7 @@
       "upstream-repo": "protocolbuffers/protobuf",
       "upstream-type": "github",
       "packagist-name": "pie-extensions/protobuf",
-      "packagist-registered": false,
+      "packagist-registered": true,
       "php-ext-name": "protobuf",
       "status": "active",
       "added": "2026-03-02",


### PR DESCRIPTION
Adds `pie-extensions/protobuf` to the extension registry.

**Upstream:** https://github.com/protocolbuffers/protobuf
**Mirror:** https://github.com/pie-extensions/protobuf

## Manual steps still needed
- [x] Register on Packagist: https://packagist.org/packages/submit
- [x] Set up Packagist webhook on the mirror repo
- [x] Update `packagist-registered: true` in registry.json