### PR TITLE
feat: add grpc mirror

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -19,7 +19,7 @@
       "upstream-repo": "grpc/grpc",
       "upstream-type": "github",
       "packagist-name": "pie-extensions/grpc",
-      "packagist-registered": false,
+      "packagist-registered": true,
       "php-ext-name": "grpc",
       "status": "active",
       "added": "2026-03-03",


### PR DESCRIPTION
Adds `pie-extensions/grpc` to the extension registry.

**Upstream:** https://github.com/grpc/grpc
**Mirror:** https://github.com/pie-extensions/grpc

## Manual steps still needed
- [x] Register on Packagist: https://packagist.org/packages/submit
- [x] Set up Packagist webhook on the mirror repo
- [ ] Update `packagist-registered: true` in registry.json