### PR TITLE
chore: offboard grpc

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -12,18 +12,6 @@
       "status": "active",
       "added": "2026-03-03",
       "notes": ""
-    },
-    {
-      "name": "grpc",
-      "mirror-repo": "pie-extensions/grpc",
-      "upstream-repo": "grpc/grpc",
-      "upstream-type": "github",
-      "packagist-name": "pie-extensions/grpc",
-      "packagist-registered": true,
-      "php-ext-name": "grpc",
-      "status": "active",
-      "added": "2026-03-04",
-      "notes": ""
     }
   ]
 }


### PR DESCRIPTION
Offboards `grpc` from the extension registry.

**Repo action:** delete (deleted)
**Registry action:** remove (removed)
**Reason:** Debug cleanup

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/grpc
- [x] Remove Packagist webhook from mirror repo (if archived, not deleted)