### PR TITLE
chore: offboard grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ pie install pie-extensions/protobuf
 <!-- extensions-table-start -->
 | Extension | Upstream | Mirror | Packagist |
 |-----------|----------|--------|-----------|
-| grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
 <!-- extensions-table-end -->
 
 See [`registry.json`](registry.json) for the full list.

--- a/registry.json
+++ b/registry.json
@@ -1,17 +1,4 @@
 {
   "$schema": "./registry.schema.json",
-  "extensions": [
-    {
-      "name": "grpc",
-      "mirror-repo": "pie-extensions/grpc",
-      "upstream-repo": "grpc/grpc",
-      "upstream-type": "github",
-      "packagist-name": "pie-extensions/grpc",
-      "packagist-registered": true,
-      "php-ext-name": "grpc",
-      "status": "active",
-      "added": "2026-03-04",
-      "notes": ""
-    }
-  ]
+  "extensions": []
 }


### PR DESCRIPTION
Offboards `grpc` from the extension registry.

**Repo action:** delete (deleted)
**Registry action:** remove (removed)
**Reason:** Debug cleanup

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/grpc
- [x] Remove Packagist webhook from mirror repo (if archived, not deleted)