### PR TITLE
chore: offboard protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ pie install pie-extensions/protobuf
 | Extension | Upstream | Mirror | Packagist |
 |-----------|----------|--------|-----------|
 | grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
-| protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
 <!-- extensions-table-end -->
 
 See [`registry.json`](registry.json) for the full list.

--- a/registry.json
+++ b/registry.json
@@ -12,18 +12,6 @@
       "status": "active",
       "added": "2026-03-05",
       "notes": ""
-    },
-    {
-      "name": "protobuf",
-      "mirror-repo": "pie-extensions/protobuf",
-      "upstream-repo": "protocolbuffers/protobuf",
-      "upstream-type": "github",
-      "packagist-name": "pie-extensions/protobuf",
-      "packagist-registered": true,
-      "php-ext-name": "protobuf",
-      "status": "active",
-      "added": "2026-03-05",
-      "notes": ""
     }
   ]
 }


### PR DESCRIPTION
Offboards `protobuf` from the extension registry.

**Repo action:** delete (deleted)
**Registry action:** remove (removed)
**Reason:** Debug cleanup

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/protobuf
- [x] Remove Packagist webhook from mirror repo (if archived, not deleted)