### PR TITLE
feat: add igbinary mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ pie install pie-extensions/protobuf
 |-----------|----------|--------|-----------|
 | protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
 | grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
+| igbinary | [igbinary/igbinary](https://github.com/igbinary/igbinary) | [pie-extensions/igbinary](https://github.com/pie-extensions/igbinary) | [pie-extensions/igbinary](https://packagist.org/packages/pie-extensions/igbinary) |
 <!-- extensions-table-end -->
 
 See [`registry.json`](registry.json) for the full list.

--- a/registry.json
+++ b/registry.json
@@ -24,6 +24,18 @@
       "status": "active",
       "added": "2026-03-11",
       "notes": ""
+    },
+    {
+      "name": "igbinary",
+      "mirror-repo": "pie-extensions/igbinary",
+      "upstream-repo": "igbinary/igbinary",
+      "upstream-type": "github",
+      "packagist-name": "pie-extensions/igbinary",
+      "packagist-registered": false,
+      "php-ext-name": "igbinary",
+      "status": "active",
+      "added": "2026-04-10",
+      "notes": ""
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -31,7 +31,7 @@
       "upstream-repo": "igbinary/igbinary",
       "upstream-type": "github",
       "packagist-name": "pie-extensions/igbinary",
-      "packagist-registered": false,
+      "packagist-registered": true,
       "php-ext-name": "igbinary",
       "status": "active",
       "added": "2026-04-10",


### PR DESCRIPTION
Adds `pie-extensions/igbinary` to the extension registry.

**Upstream:** https://github.com/igbinary/igbinary
**Mirror:** https://github.com/pie-extensions/igbinary

## Manual steps still needed
- [x] Register on Packagist: https://packagist.org/packages/submit
- [x] Set up Packagist webhook on the mirror repo
- [x] Update `packagist-registered: true` in registry.json