### PR TITLE
chore: offboard grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ pie install pie-extensions/protobuf
 | Extension | Upstream | Mirror | Packagist |
 |-----------|----------|--------|-----------|
 | protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
-| grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
 | igbinary | [igbinary/igbinary](https://github.com/igbinary/igbinary) | [pie-extensions/igbinary](https://github.com/pie-extensions/igbinary) | [pie-extensions/igbinary](https://packagist.org/packages/pie-extensions/igbinary) |
 | redis | [phpredis/phpredis](https://github.com/phpredis/phpredis) | [pie-extensions/redis](https://github.com/pie-extensions/redis) | [pie-extensions/redis](https://packagist.org/packages/pie-extensions/redis) |
 <!-- extensions-table-end -->

--- a/registry.json
+++ b/registry.json
@@ -14,18 +14,6 @@
       "notes": ""
     },
     {
-      "name": "grpc",
-      "mirror-repo": "pie-extensions/grpc",
-      "upstream-repo": "grpc/grpc",
-      "upstream-type": "github",
-      "packagist-name": "pie-extensions/grpc",
-      "packagist-registered": true,
-      "php-ext-name": "grpc",
-      "status": "active",
-      "added": "2026-03-11",
-      "notes": ""
-    },
-    {
       "name": "igbinary",
       "mirror-repo": "pie-extensions/igbinary",
       "upstream-repo": "igbinary/igbinary",


### PR DESCRIPTION
Offboards `grpc` from the extension registry.

**Repo action:** delete (deleted)
**Registry action:** remove (removed)
**Reason:** Debug cleanup

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/grpc
- [x] Remove Packagist webhook from mirror repo (if archived, not deleted)