### PR TITLE
feat: add redis mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pie install pie-extensions/protobuf
 | protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
 | igbinary | [igbinary/igbinary](https://github.com/igbinary/igbinary) | [pie-extensions/igbinary](https://github.com/pie-extensions/igbinary) | [pie-extensions/igbinary](https://packagist.org/packages/pie-extensions/igbinary) |
 | grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
+| redis | [phpredis/phpredis](https://github.com/phpredis/phpredis) | [pie-extensions/redis](https://github.com/pie-extensions/redis) | [pie-extensions/redis](https://packagist.org/packages/pie-extensions/redis) |
 <!-- extensions-table-end -->
 
 See [`registry.json`](registry.json) for the full list. See [`.pie-mirror.example.json`](.pie-mirror.example.json) for all available mirror configuration options.

--- a/registry.json
+++ b/registry.json
@@ -36,6 +36,18 @@
       "status": "active",
       "added": "2026-04-12",
       "notes": ""
+    },
+    {
+      "name": "redis",
+      "mirror-repo": "pie-extensions/redis",
+      "upstream-repo": "phpredis/phpredis",
+      "upstream-type": "github",
+      "packagist-name": "pie-extensions/redis",
+      "packagist-registered": false,
+      "php-ext-name": "redis",
+      "status": "active",
+      "added": "2026-04-12",
+      "notes": ""
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -43,7 +43,7 @@
       "upstream-repo": "phpredis/phpredis",
       "upstream-type": "github",
       "packagist-name": "pie-extensions/redis",
-      "packagist-registered": false,
+      "packagist-registered": true,
       "php-ext-name": "redis",
       "status": "active",
       "added": "2026-04-12",


### PR DESCRIPTION
Adds `pie-extensions/redis` to the extension registry.

**Upstream:** https://github.com/phpredis/phpredis
**Mirror:** https://github.com/pie-extensions/redis

## Manual steps still needed
- [x] Register on Packagist: https://packagist.org/packages/submit
- [x] Set up Packagist webhook on the mirror repo
- [x] Update `packagist-registered: true` in registry.json