### PR TITLE
chore: offboard redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ pie install pie-extensions/protobuf
 <!-- extensions-table-start -->
 | Extension | Upstream | Mirror | Packagist |
 |-----------|----------|--------|-----------|
-| redis | [phpredis/phpredis](https://github.com/phpredis/phpredis) | [pie-extensions/redis](https://github.com/pie-extensions/redis) | [pie-extensions/redis](https://packagist.org/packages/pie-extensions/redis) |
 | grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
 | protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
 | igbinary | [igbinary/igbinary](https://github.com/igbinary/igbinary) | [pie-extensions/igbinary](https://github.com/pie-extensions/igbinary) | [pie-extensions/igbinary](https://packagist.org/packages/pie-extensions/igbinary) |

--- a/registry.json
+++ b/registry.json
@@ -2,18 +2,6 @@
   "$schema": "./registry.schema.json",
   "extensions": [
     {
-      "name": "redis",
-      "mirror-repo": "pie-extensions/redis",
-      "upstream-repo": "phpredis/phpredis",
-      "upstream-type": "github",
-      "packagist-name": "pie-extensions/redis",
-      "packagist-registered": true,
-      "php-ext-name": "redis",
-      "status": "active",
-      "added": "2026-04-12",
-      "notes": ""
-    },
-    {
       "name": "grpc",
       "mirror-repo": "pie-extensions/grpc",
       "upstream-repo": "grpc/grpc",


### PR DESCRIPTION
Offboards `redis` from the extension registry.

**Repo action:** delete (deleted)
**Registry action:** remove (removed)
**Reason:** Debug cleanup

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/redis
- [x] Remove Packagist webhook from mirror repo (if archived, not deleted)