### PR TITLE
chore: offboard protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ pie install pie-extensions/protobuf
 | Extension | Upstream | Mirror | Packagist |
 |-----------|----------|--------|-----------|
 | grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
-| protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
 <!-- extensions-table-end -->
 
 See [`registry.json`](registry.json) for the full list. See [`.pie-mirror.example.json`](.pie-mirror.example.json) for all available mirror configuration options.

--- a/registry.json
+++ b/registry.json
@@ -21,9 +21,9 @@
       "packagist-name": "pie-extensions/protobuf",
       "packagist-registered": true,
       "php-ext-name": "protobuf",
-      "status": "active",
+      "status": "deprecated",
       "added": "2026-04-21",
-      "notes": ""
+      "notes": "Moving to a new org"
     },
     {
       "name": "igbinary",


### PR DESCRIPTION
Offboards `protobuf` from the extension registry.

**Repo action:** archive (archived)
**Registry action:** deprecate (deprecated)
**Reason:** Moving to a new org

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/protobuf
- [ ] Remove Packagist webhook from mirror repo (if archived, not deleted)