### PR TITLE
chore: offboard grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ pie install pie-extensions/protobuf
 <!-- extensions-table-start -->
 | Extension | Upstream | Mirror | Packagist |
 |-----------|----------|--------|-----------|
-| grpc | [grpc/grpc](https://github.com/grpc/grpc) | [pie-extensions/grpc](https://github.com/pie-extensions/grpc) | [pie-extensions/grpc](https://packagist.org/packages/pie-extensions/grpc) |
 | protobuf | [protocolbuffers/protobuf](https://github.com/protocolbuffers/protobuf) | [pie-extensions/protobuf](https://github.com/pie-extensions/protobuf) | [pie-extensions/protobuf](https://packagist.org/packages/pie-extensions/protobuf) |
 <!-- extensions-table-end -->
 

--- a/registry.json
+++ b/registry.json
@@ -9,9 +9,9 @@
       "packagist-name": "pie-extensions/grpc",
       "packagist-registered": true,
       "php-ext-name": "grpc",
-      "status": "active",
+      "status": "deprecated",
       "added": "2026-04-21",
-      "notes": ""
+      "notes": "Moving to a new org"
     },
     {
       "name": "protobuf",


### PR DESCRIPTION
Offboards `grpc` from the extension registry.

**Repo action:** archive (archived)
**Registry action:** deprecate (deprecated)
**Reason:** Moving to a new org

## Manual steps still needed
- [x] Remove/abandon Packagist package if registered: https://packagist.org/packages/pie-extensions/grpc
- [x] Remove Packagist webhook from mirror repo (if archived, not deleted)